### PR TITLE
remove click event listener and change form action

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,11 +26,10 @@ app.post('/theaters', urlencodedParser, (req, res) => {
 
 app.get('/location', (req, res) => res.json(searchObj))
 
-
 app.get('/getData', (req, res) => {
     const date = searchObj.date
     const zip = searchObj.zipcode
-    reqPromise('http://data.tmsapi.com/v1.1/movies/showings?startDate=' + date + '&zip=' + zip + '&api_key=2dp7mrfsmqm3cgupxx4vh5e6')
+    reqPromise('http://data.tmsapi.com/v1.1/movies/showings?startDate=' + date + '&zip=' + zip + '&api_key=2tevkc8394dkkyk4ezzc8t5m')
 
     .then((response) => {
         res.json(response)

--- a/public/assets/javascript/theaters.js
+++ b/public/assets/javascript/theaters.js
@@ -23,8 +23,6 @@ $(document).ready(function () {
         return false;
     });
 
-    // TODO: write addGoogleMaps function
-
     // Passes data from the index page to populate the search form on theaters page
     $.ajax({
         url: "/location",
@@ -43,14 +41,6 @@ $(document).ready(function () {
         url: "/getData",
         method: "GET"
     }).then(response => getMovieData(response));
-
-    // Allows user to resubmit search from theaters display page
-    $("#start").on("click", function (event) {
-        $.ajax({
-            url: "/getData",
-            method: "GET"
-        }).then((response) => getMovieData(response))
-    })
 
     function getMovieData(response) {
         var uniqueTheatreArray = [];
@@ -75,9 +65,6 @@ $(document).ready(function () {
                 displayObject[theaterData[key].names] = theaterData[key].names + theaterData[key].titles;
             }
         }
-
-
-        // Call addGoogleMaps function here, passing theaterData
 
         var holder = {};
         theaterData.forEach(function (element) {

--- a/public/theaters.html
+++ b/public/theaters.html
@@ -67,7 +67,7 @@
             <div class="row">
 
                 <div class="col-md-6" id="search-results">
-                    <form>
+                    <form id="resubmit-search" action="/theaters" method="post">
                         <div class="form-group">
                             <div class="row">
                                 <div class="col-md-4">


### PR DESCRIPTION
search from theaters page now works. Turns out the button didn't need to be wired, we can rely on the normal form action to refine/resubmit search terms.